### PR TITLE
Rename and provide improved description

### DIFF
--- a/src/examples/python_pip_install.yml
+++ b/src/examples/python_pip_install.yml
@@ -1,5 +1,5 @@
 description: >
-  Python usage examples.
+  Install dependencies from Cloudsmith using pip
 usage:
   version: 2.1
   orbs:


### PR DESCRIPTION
## Why?

Improve the pip install example documentation

## What?

- Renamed the python.yml file to python_pip_install.yml
- Provided an improved example description

