### PR TITLE
add pipenv example yml

### DIFF
--- a/src/examples/install_package_using_python_orb_pipenv.yml
+++ b/src/examples/install_package_using_python_orb_pipenv.yml
@@ -1,0 +1,26 @@
+description: >
+  Install a package from Cloudsmith using the Python orb, via pipenv.
+usage:
+  version: 2.1
+  orbs:
+    python: circleci/python@2.1.1
+    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0.0
+jobs:
+  build:
+    docker:
+      - image: cimg/python:3.11-node
+    steps:
+      - checkout
+      - run: python -m ensurepip --upgrade
+      - cloudsmith-python/set_env_vars_for_pip:
+          repository: financial-times-internal-releases
+      - run: python -m pip config set global.index-url "$CLOUDSMITH_PIP_INDEX_URL"
+      - run:
+            name: Install pipenv
+            command: pip install pipenv
+      - python/install-packages:
+            pkg-manager: pipenv
+  workflows:
+    main:
+      jobs:
+        - build


### PR DESCRIPTION
## Why?

We're adding examples for use of the Python orb with pipenv.

## What?

 - A new example including use of the python orb with pipenv.