### PR TITLE
Tweak pipenv example

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -72,19 +72,17 @@ jobs:
       - cloudsmith-python/set_env_vars_for_pip:
           repository: "circleci-orb-testing"
       - run: python -m pip install pipenv
-      - run:
-        name: Create Pipfile with CLOUDSMITH_PIP_INDEX_URL
-        command: |
-          cat <<EOF >> Pipfile
-          [[source]]
-          url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE"
-          verify_ssl = true
-          name = "cloudsmith"
-          [packages]
-          simplepkg = "0.0.1"
-          [requires]
-          python_version = "3.9"
-          EOF
+      - run: |
+        cat <<EOF >> Pipfile
+        [[source]]
+        url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE"
+        verify_ssl = true
+        name = "cloudsmith"
+        [packages]
+        simplepkg = "0.0.1"
+        [requires]
+        python_version = "3.9"
+        EOF
       - run: pipenv install
 
   test-configure_pip_example:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -184,6 +184,9 @@ workflows:
       - test-pip_install_requirements_example:
           context: circleci-orb-publishing
           filters: *filters
+      - test-pipenv_install_package_example:
+          context: circleci-orb-publishing
+          filters: *filters
       - test-configure_pip_example:
           context: circleci-orb-publishing
           filters: *filters
@@ -211,6 +214,7 @@ workflows:
             - test-set_env_vars_for_pip
             - test-pip_install_package_example
             - test-pip_install_requirements_example
+            - test-pipenv_install_package_example
             - test-configure_pip_example
             - test-set_env_vars_for_twine
             - test-upload_package_using_twine

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -77,7 +77,7 @@ jobs:
           command: |
             cat \<< EOT >> Pipfile
             [[source]]
-            url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE"
+            url = "\$CLOUDSMITH_PIP_INDEX_URL"
             verify_ssl = true
             name = "cloudsmith"
             [packages]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -72,7 +72,9 @@ jobs:
       - cloudsmith-python/set_env_vars_for_pip:
           repository: "circleci-orb-testing"
       - run: python -m pip install pipenv
-      - run: |
+      - run:
+        name: Create Pipfile with CLOUDSMITH_PIP_INDEX_URL
+        command: |
           cat <<EOF >> Pipfile
           [[source]]
           url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -73,16 +73,16 @@ jobs:
           repository: "circleci-orb-testing"
       - run: python -m pip install pipenv
       - run: |
-        cat <<EOF >> Pipfile
+        cat <<EOF >> Pipfile:
         [[source]]
-        url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE"
-        verify_ssl = true
-        name = "cloudsmith"
+        url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE":
+        verify_ssl = true:
+        name = "cloudsmith":
         [packages]
-        simplepkg = "0.0.1"
+        simplepkg = "0.0.1":
         [requires]
-        python_version = "3.9"
-        EOF
+        python_version = "3.9":
+        EOF:
       - run: pipenv install
 
   test-configure_pip_example:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -73,16 +73,16 @@ jobs:
           repository: "circleci-orb-testing"
       - run: python -m pip install pipenv
       - run: |
-        cat <<EOF >> Pipfile:
-        [[source]]
-        url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE":
-        verify_ssl = true:
-        name = "cloudsmith":
+        cat <<EOF >> Pipfile
+        '[[source]]
+        url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE"
+        verify_ssl = true
+        name = "cloudsmith"
         [packages]
-        simplepkg = "0.0.1":
+        simplepkg = "0.0.1"
         [requires]
-        python_version = "3.9":
-        EOF:
+        python_version = "3.9"'
+        EOF
       - run: pipenv install
 
   test-configure_pip_example:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -72,17 +72,19 @@ jobs:
       - cloudsmith-python/set_env_vars_for_pip:
           repository: "circleci-orb-testing"
       - run: python -m pip install pipenv
-      - run: |
-        cat <<EOF >> Pipfile
-        '[[source]]
-        url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE"
-        verify_ssl = true
-        name = "cloudsmith"
-        [packages]
-        simplepkg = "0.0.1"
-        [requires]
-        python_version = "3.9"'
-        EOF
+      - run:
+          name: Create Pipfile
+          command: |
+            cat << EOT >> Pipfile
+            [[source]]
+            url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE"
+            verify_ssl = true
+            name = "cloudsmith"
+            [packages]
+            simplepkg = "0.0.1"
+            [requires]
+            python_version = "3.9"
+            EOT
       - run: pipenv install
 
   test-configure_pip_example:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -75,7 +75,7 @@ jobs:
       - run:
           name: Create Pipfile
           command: |
-            cat << EOT >> Pipfile
+            cat \<< EOT >> Pipfile
             [[source]]
             url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE"
             verify_ssl = true

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -31,7 +31,7 @@ jobs:
           repository: "circleci-orb-testing"
       - run:
           name: Assert environment variables have been set
-          command: | 
+          command: |
             if [ $CLOUDSMITH_DOWNLOADS_DOMAIN != "packages.ft.com" ]
             then
               echo "Test failed: CLOUDSMITH_DOWNLOADS_DOMAIN has not been set correctly."
@@ -63,6 +63,28 @@ jobs:
           repository: "circleci-orb-testing"
       - run: python -m pip install -r requirements.txt --index-url "$CLOUDSMITH_PIP_INDEX_URL"
 
+  test-pipenv_install_package_example:
+    docker:
+      - image: cimg/python:3.9
+    steps:
+      - checkout
+      - run: python -m ensurepip --upgrade
+      - cloudsmith-python/set_env_vars_for_pip:
+          repository: "circleci-orb-testing"
+      - run: python -m pip install pipenv
+      - run: |
+          cat <<EOF >> Pipfile
+          [[source]]
+          url = "\$CLOUDSMITH_PIP_INDEX_URL_FALSE"
+          verify_ssl = true
+          name = "cloudsmith"
+          [packages]
+          simplepkg = "0.0.1"
+          [requires]
+          python_version = "3.9"
+          EOF
+      - run: pipenv install
+
   test-configure_pip_example:
     docker:
       - image: cimg/python:3.9
@@ -84,7 +106,7 @@ jobs:
           repository: "circleci-orb-testing"
       - run:
           name: Assert environment variables have been set
-          command: | 
+          command: |
             if [ $CLOUDSMITH_TWINE_REPOSITORY_URL != "https://python.cloudsmith.io/financial-times/circleci-orb-testing/" ]
             then
               echo "Test failed: CLOUDSMITH_TWINE_REPOSITORY_URL has not been set correctly."

--- a/src/examples/configure_pip_index_url.yml
+++ b/src/examples/configure_pip_index_url.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0.0
+    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0
   jobs:
     build:
       docker:

--- a/src/examples/install_package_using_python_orb_pipenv.yml
+++ b/src/examples/install_package_using_python_orb_pipenv.yml
@@ -8,13 +8,12 @@ usage:
 jobs:
   build:
     docker:
-      - image: cimg/python:3.11-node
+      - image: cimg/python:3.9
     steps:
       - checkout
       - run: python -m ensurepip --upgrade
       - cloudsmith-python/set_env_vars_for_pip:
           repository: your-repository-id
-      - run: python -m pip config set global.index-url "$CLOUDSMITH_PIP_INDEX_URL"
       - run:
           name: Install pipenv
           command: pip install pipenv

--- a/src/examples/pip_install_package.yml
+++ b/src/examples/pip_install_package.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0.0
+    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0
   jobs:
     build:
       docker:

--- a/src/examples/pip_install_requirements.yml
+++ b/src/examples/pip_install_requirements.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0.0
+    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0
   jobs:
     build:
       docker:

--- a/src/examples/pipenv_install_packages.yml
+++ b/src/examples/pipenv_install_packages.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0.0
+    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0
 jobs:
   build:
     docker:

--- a/src/examples/pipenv_install_packages.yml
+++ b/src/examples/pipenv_install_packages.yml
@@ -1,9 +1,8 @@
 description: >
-  Install a package from Cloudsmith using the Python orb, via pipenv.
+  Install a package from Cloudsmith using pipenv. The source URL in the Pipfile must reference $CLOUDSMITH_PIP_INDEX_URL.
 usage:
   version: 2.1
   orbs:
-    python: circleci/python@2.1.1
     cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0.0
 jobs:
   build:
@@ -14,11 +13,9 @@ jobs:
       - run: python -m ensurepip --upgrade
       - cloudsmith-python/set_env_vars_for_pip:
           repository: your-repository-id
-      - run:
-          name: Install pipenv
-          command: pip install pipenv
-      - python/install-packages:
-          pkg-manager: pipenv
+      - run: python -m pip install pipenv
+      - run: pipenv install
+
   workflows:
     main:
       jobs:

--- a/src/examples/upload_package_using_cli.yml
+++ b/src/examples/upload_package_using_cli.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0.0
+    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0
   jobs:
     build:
       docker:

--- a/src/examples/upload_package_using_twine.yml
+++ b/src/examples/upload_package_using_twine.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0.0
+    cloudsmith-python: ft-circleci-orbs/cloudsmith-python@1.0
   jobs:
     build:
       docker:


### PR DESCRIPTION
## Why?

We previously created an example on how to use cloudsmith via pipenv and the python orb
We're tweaking the example to make it more relevant and we're adding a test.

## What?

- Renaming example from `install_package_using_python_orb_pipenv.yml` to `pipenv_install_packages.yml`
- Removed usage of the Python orb
- Changed order of commands
- Bumped orb semver to 1.0 in examples to anticipate patch changes in future
- Included a new pipenv test, where we're manually creating a pipfile
- some cleaning up of blank space and other formatting
