### PR TITLE
Update simplepkg ver in test configure pip example to avoid blocking.

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -153,7 +153,7 @@ jobs:
       - image: cimg/python:3.9
     steps:
       - checkout
-      - run: echo "simplepkg==0.0.1" > requirements.txt
+      - run: echo "simplepkg==0.4.3" > requirements.txt
       - cloudsmith-python/set_env_vars_for_pip:
           repository: "circleci-orb-testing"
       - run: python -m pip config set global.index-url "$CLOUDSMITH_PIP_INDEX_URL"


### PR DESCRIPTION
## Why?

- Update simplepkg ver in test configure pip example to avoid upload/download blocking in CI pipeline.