### PR TITLE
Update python image version

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,7 +23,7 @@ jobs:
 
   test-set_env_vars_for_pip:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -46,7 +46,7 @@ jobs:
 
   test-pip_install_package_example:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13
     steps:
       - checkout
       - cloudsmith-python/set_env_vars_for_pip:
@@ -55,7 +55,7 @@ jobs:
 
   test-pip_install_requirements_example:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13
     steps:
       - checkout
       - run: echo "simplepkg==0.0.1" > requirements.txt
@@ -65,7 +65,7 @@ jobs:
 
   test-pipenv_install_package_example:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13
     steps:
       - checkout
       - run: python -m ensurepip --upgrade
@@ -89,7 +89,7 @@ jobs:
 
   test-set_env_vars_for_poetry:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -112,7 +112,7 @@ jobs:
 
   test-upload_package_using_poetry:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -131,7 +131,7 @@ jobs:
 
   test-poetry_install_packages_example:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13
     steps:
       - checkout
       - cloudsmith-python/set_env_vars_for_poetry:
@@ -150,7 +150,7 @@ jobs:
             
   test-configure_pip_example:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13
     steps:
       - checkout
       - run: echo "simplepkg==0.4.3" > requirements.txt
@@ -161,7 +161,7 @@ jobs:
 
   test-set_env_vars_for_twine:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -189,7 +189,7 @@ jobs:
 
   test-upload_package_using_twine:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -218,7 +218,7 @@ jobs:
 
   test-upload_package_using_cli:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -132,7 +132,8 @@ jobs:
           command: |
             poetry new poetry-package
             cd poetry-package
-            poetry source add --priority=default cloudsmith-source-url https://python.cloudsmith.io/financial-times/circleci-orb-testing/
+            # Configure the repository for publishing (not just as a source)
+            poetry config repositories.cloudsmith-source-url https://python.cloudsmith.io/financial-times/circleci-orb-testing/
             poetry config http-basic.cloudsmith-source-url $CLOUDSMITH_POETRY_USERNAME $CLOUDSMITH_POETRY_PASSWORD
             poetry build
             poetry publish -r cloudsmith-source-url

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -116,14 +116,14 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - run: python -m ensurepip --upgrade
       - run: 
-          name: Install Poetry
+          name: Install Poetry using official installer
           command: |
-            python -m pip install poetry --upgrade --user
+            curl -sSL https://install.python-poetry.org | python3 -
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV
             source $BASH_ENV
             poetry --version
+            poetry config --list
       - cloudsmith-python/set_env_vars_for_poetry:
           repository: circleci-orb-testing
       - run:
@@ -142,14 +142,14 @@ jobs:
       - image: cimg/python:3.13
     steps:
       - checkout
-      - run: python -m ensurepip --upgrade
       - run: 
-          name: Install Poetry
+          name: Install Poetry using official installer
           command: |
-            python -m pip install poetry --upgrade --user
+            curl -sSL https://install.python-poetry.org | python3 -
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV
             source $BASH_ENV
             poetry --version
+            poetry config --list
       - cloudsmith-python/set_env_vars_for_poetry:
           repository: circleci-orb-testing
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -116,6 +116,8 @@ jobs:
     resource_class: small
     steps:
       - checkout
+      - run: python -m ensurepip --upgrade
+      - run: python -m pip install poetry --upgrade --user
       - cloudsmith-python/set_env_vars_for_poetry:
           repository: circleci-orb-testing
       - run:
@@ -134,6 +136,8 @@ jobs:
       - image: cimg/python:3.13
     steps:
       - checkout
+      - run: python -m ensurepip --upgrade
+      - run: python -m pip install poetry --upgrade --user
       - cloudsmith-python/set_env_vars_for_poetry:
           repository: circleci-orb-testing
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -117,7 +117,13 @@ jobs:
     steps:
       - checkout
       - run: python -m ensurepip --upgrade
-      - run: python -m pip install poetry --upgrade --user
+      - run: 
+          name: Install Poetry
+          command: |
+            python -m pip install poetry --upgrade --user
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV
+            source $BASH_ENV
+            poetry --version
       - cloudsmith-python/set_env_vars_for_poetry:
           repository: circleci-orb-testing
       - run:
@@ -137,7 +143,13 @@ jobs:
     steps:
       - checkout
       - run: python -m ensurepip --upgrade
-      - run: python -m pip install poetry --upgrade --user
+      - run: 
+          name: Install Poetry
+          command: |
+            python -m pip install poetry --upgrade --user
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV
+            source $BASH_ENV
+            poetry --version
       - cloudsmith-python/set_env_vars_for_poetry:
           repository: circleci-orb-testing
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -159,7 +159,8 @@ jobs:
           command: |
             poetry new poetry-package
             cd poetry-package
-            poetry source add --priority=default cloudsmith-source-url https://packages.ft.com/basic/circleci-orb-testing/python/simple/
+            # Configure the repository for publishing (not just as a source)
+            poetry config repositories.cloudsmith-source-url https://python.cloudsmith.io/financial-times/circleci-orb-testing/
             poetry config http-basic.cloudsmith-source-url $CLOUDSMITH_POETRY_USERNAME $CLOUDSMITH_POETRY_PASSWORD
             poetry add -q simplepkg
             poetry install

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -83,7 +83,7 @@ jobs:
             [packages]
             simplepkg = "0.4.3"
             [requires]
-            python_version = "3.9"
+            python_version = "3.13"
             EOT
       - run: pipenv install
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ orb.yml
 
 .circleci/simplepkg-py/dist
 .circleci/simplepkg-py/simplepkg.egg-info
+
+# Folders
+/bin
+/lib

--- a/src/examples/configure_pip_index_url.yml
+++ b/src/examples/configure_pip_index_url.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     build:
       docker:
-        - image: cimg/python:3.9
+        - image: cimg/python:3.13
       steps:
         - checkout
         - run: python -m ensurepip --upgrade

--- a/src/examples/pip_install_package.yml
+++ b/src/examples/pip_install_package.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     build:
       docker:
-        - image: cimg/python:3.9
+        - image: cimg/python:3.13
       steps:
         - checkout
         - run: python -m ensurepip --upgrade

--- a/src/examples/pip_install_requirements.yml
+++ b/src/examples/pip_install_requirements.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     build:
       docker:
-        - image: cimg/python:3.9
+        - image: cimg/python:3.13
       steps:
         - checkout
         - run: python -m ensurepip --upgrade

--- a/src/examples/pipenv_install_packages.yml
+++ b/src/examples/pipenv_install_packages.yml
@@ -1,5 +1,6 @@
 description: >
   Install a package from Cloudsmith using pipenv. The source URL in the Pipfile must reference $CLOUDSMITH_PIP_INDEX_URL.
+  Note: Ensure the python_version in your Pipfile matches the Python version in your Docker image to avoid installation errors.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/pipenv_install_packages.yml
+++ b/src/examples/pipenv_install_packages.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     build:
       docker:
-        - image: cimg/python:3.9
+        - image: cimg/python:3.13
       steps:
         - checkout
         - run: python -m ensurepip --upgrade

--- a/src/examples/poetry_install_packages.yml
+++ b/src/examples/poetry_install_packages.yml
@@ -2,6 +2,7 @@ description: >
   Install a package from Cloudsmith using poetry.
   The source URL in pyproject.toml must be set to https://packages.ft.com/basic/your-repository-id/python/simple/
   and the corresponding cloudsmith-source-url parameter is an arbitrary label for the Cloudsmith Source URL.
+  Note: Ensure the Python version requirement in your pyproject.toml matches the Python version in your Docker image.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/poetry_install_packages.yml
+++ b/src/examples/poetry_install_packages.yml
@@ -13,6 +13,8 @@ usage:
         - image: cimg/python:3.13
       steps:
         - checkout
+        - run: python -m ensurepip --upgrade
+        - run: python -m pip install poetry --upgrade --user
         - cloudsmith-python/set_env_vars_for_poetry:
             repository: your-repository-id
         - run:

--- a/src/examples/poetry_install_packages.yml
+++ b/src/examples/poetry_install_packages.yml
@@ -9,7 +9,7 @@ usage:
   jobs:
     build:
       docker:
-        - image: cimg/python:3.9
+        - image: cimg/python:3.13
       steps:
         - checkout
         - cloudsmith-python/set_env_vars_for_poetry:

--- a/src/examples/upload_package_using_cli.yml
+++ b/src/examples/upload_package_using_cli.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     build:
       docker:
-        - image: cimg/python:3.9
+        - image: cimg/python:3.13
       steps:
         - checkout
         - run: python -m ensurepip --upgrade

--- a/src/examples/upload_package_using_poetry.yml
+++ b/src/examples/upload_package_using_poetry.yml
@@ -12,6 +12,8 @@ usage:
         - image: cimg/python:3.13
       steps:
         - checkout
+        - run: python -m ensurepip --upgrade
+        - run: python -m pip install poetry --upgrade --user
         - cloudsmith-python/set_env_vars_for_poetry:
             repository: your-repository-id
         - run:

--- a/src/examples/upload_package_using_poetry.yml
+++ b/src/examples/upload_package_using_poetry.yml
@@ -9,7 +9,7 @@ usage:
   jobs:
     build:
       docker:
-        - image: cimg/python:3.9
+        - image: cimg/python:3.13
       steps:
         - checkout
         - cloudsmith-python/set_env_vars_for_poetry:

--- a/src/examples/upload_package_using_twine.yml
+++ b/src/examples/upload_package_using_twine.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     build:
       docker:
-        - image: cimg/python:3.9
+        - image: cimg/python:3.13
       steps:
         - checkout
         - run: python -m ensurepip --upgrade


### PR DESCRIPTION
## Why?

- We want our orbs to be up-to-date

## What?

- Update python image version to `v3.13`
- The python image for v3.13 no longer comes with poetry installed, so this had to be done separately
- Define path for accessing poetry